### PR TITLE
Add file type for notebooks (fix #6)

### DIFF
--- a/api.py
+++ b/api.py
@@ -25,7 +25,7 @@ class RmFile:
         self.files = [] if self.isFolder else None
 
         # Determine file type:
-        self.isNotebook = not self.isFolder and metadata['fileType'] == ''
+        self.isNotebook = not self.isFolder and metadata['fileType'] == 'notebook'
         self.isPdf = not self.isFolder and metadata['fileType'] == 'pdf'
         self.isEpub = not self.isFolder and metadata['fileType'] == 'epub'
 


### PR DESCRIPTION
Seems like the 1.8.x update added a fileType meta for notebooks. Adding the fileType reported by the stats.py error fixes file syncing for me.